### PR TITLE
fix minor mistake

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -182,7 +182,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   ///         return overflowed ? nil : result
   ///     }
   ///     print(nonOverflowingSquare)
-  ///     // Prints "Optional(1746)"
+  ///     // Prints "Optional(1764)"
   ///
   /// - Parameter transform: A closure that takes the unwrapped value
   ///   of the instance.  
@@ -190,7 +190,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   ///   returns `nil`.
   @_inlineable
   public func flatMap<U>(
-    _ transform: (Wrapped) throws -> U?
+    _ transform: (Unwrapped) throws -> U?
   ) rethrows -> U? {
     switch self {
     case .some(let y):


### PR DESCRIPTION
Use the `flatMap` method. Parameter transform: A closure that takes the unwrapped value, right?
and the example's result is 1764. not 1746.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
